### PR TITLE
Add configurable scheduler and docs for tickers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ Edit `config.yaml` to specify tickers, social keywords, thresholds, schedule and
 `discord_webhook_url`. The template includes comments describing each setting to
 make configuration straightforward.
 
+### Selecting tickers
+
+The `tickers` list in `config.yaml` determines which stocks are tracked.
+Add or remove symbols under this key to customize alerts. Example:
+
+```yaml
+tickers:
+  - AAPL
+  - MSFT
+  - GOOGL
+```
+
+
 ### Switching sentiment models
 
 `sentiment.py` loads a transformer model from the local filesystem. To use a

--- a/config.yaml
+++ b/config.yaml
@@ -12,5 +12,5 @@ thresholds:
     buy: 0.2
     sell: -0.2
 schedule:
-  every: 30 minutes
+  every: 15 minutes
 discord_webhook_url: "YOUR_DISCORD_WEBHOOK_URL"

--- a/run_scheduler.py
+++ b/run_scheduler.py
@@ -3,6 +3,8 @@
 from apscheduler.schedulers.background import BackgroundScheduler
 from datetime import datetime
 import time
+
+from signals import load_config
 import main
 
 
@@ -12,8 +14,15 @@ def run_job():
 
 
 def start():
+    config = load_config()
+    interval = config.get("schedule", {}).get("every", "30 minutes")
+    try:
+        minutes = int(str(interval).split()[0])
+    except (ValueError, IndexError):
+        minutes = 30
+
     scheduler = BackgroundScheduler()
-    scheduler.add_job(run_job, "interval", minutes=30)
+    scheduler.add_job(run_job, "interval", minutes=minutes)
     scheduler.start()
     try:
         while True:


### PR DESCRIPTION
## Summary
- make scheduler read interval from `config.yaml`
- update default schedule to 15 minutes
- document how to set tickers in the README

## Testing
- `python3 -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_6876febd416c832398be3d29e4599382