### PR TITLE
Fix missing technical analysis library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ yfinance
 transformers
 torch
 backtrader
-technical-analysis-library
+technical-analysis
 discord-webhook
 apscheduler
 streamlit


### PR DESCRIPTION
## Summary
- fix invalid package name in requirements

## Testing
- `python3 -m unittest -v`

------
https://chatgpt.com/codex/tasks/task_e_68784ba89b64832381c9307b011bb44a