### PR TITLE
Fix MACD util and test

### DIFF
--- a/indicators.py
+++ b/indicators.py
@@ -21,8 +21,21 @@ def compute_sma(df: pd.DataFrame, period: int) -> float:
 
 
 def compute_macd(df: pd.DataFrame) -> float:
-    """Compute MACD and return last histogram value."""
+    """Compute MACD histogram and return the last value.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Price dataframe containing a ``Close`` column.
+
+    Returns
+    -------
+    float
+        The most recent MACD histogram value. ``0.0`` if ``df`` is empty.
+    """
     if df.empty:
         return 0.0
-    macd_df = ta.macd(df["Close"])
-    return macd_df["MACDh_12_26_9"].iloc[-1]
+
+    # ``ta.macd`` returns a Series containing the MACD histogram values.
+    macd_series = ta.macd(df["Close"])
+    return float(macd_series.iloc[-1])

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,0 +1,17 @@
+import unittest
+import pandas as pd
+
+from indicators import compute_macd
+
+
+class TestIndicators(unittest.TestCase):
+    """Tests for technical indicator helpers."""
+
+    def test_compute_macd_returns_float(self) -> None:
+        df = pd.DataFrame({"Close": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]})
+        value = compute_macd(df)
+        self.assertIsInstance(value, float)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- compute MACD using technical_analysis.macd series helper
- test that compute_macd returns float

## Testing
- `python3 -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_68784fca87808323accd9dc7c902c6e7