### PR TITLE
Fix RSI and SMA return types

### DIFF
--- a/indicators.py
+++ b/indicators.py
@@ -5,19 +5,45 @@ from technical_analysis import indicators as ta
 
 
 def compute_rsi(df: pd.DataFrame, period: int = 14) -> float:
-    """Compute RSI indicator."""
+    """Compute the Relative Strength Index.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Price dataframe containing a ``Close`` column.
+    period : int, optional
+        Number of periods used to compute the indicator. Defaults to ``14``.
+
+    Returns
+    -------
+    float
+        The most recent RSI value. ``0.0`` if ``df`` is empty.
+    """
     if df.empty:
         return 0.0
     rsi_series = ta.rsi(df["Close"], period=period)
-    return rsi_series.iloc[-1]
+    return float(rsi_series.iloc[-1])
 
 
 def compute_sma(df: pd.DataFrame, period: int) -> float:
-    """Compute Simple Moving Average."""
+    """Compute the Simple Moving Average.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Price dataframe containing a ``Close`` column.
+    period : int
+        Number of periods used for the average.
+
+    Returns
+    -------
+    float
+        The most recent SMA value. ``0.0`` if ``df`` is empty.
+    """
     if df.empty:
         return 0.0
     sma = ta.sma(df["Close"], period=period)
-    return sma.iloc[-1]
+    return float(sma.iloc[-1])
 
 
 def compute_macd(df: pd.DataFrame) -> float:

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,7 +1,7 @@
 import unittest
 import pandas as pd
 
-from indicators import compute_macd
+from indicators import compute_macd, compute_rsi, compute_sma
 
 
 class TestIndicators(unittest.TestCase):
@@ -10,6 +10,16 @@ class TestIndicators(unittest.TestCase):
     def test_compute_macd_returns_float(self) -> None:
         df = pd.DataFrame({"Close": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]})
         value = compute_macd(df)
+        self.assertIsInstance(value, float)
+
+    def test_compute_rsi_returns_float(self) -> None:
+        df = pd.DataFrame({"Close": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]})
+        value = compute_rsi(df)
+        self.assertIsInstance(value, float)
+
+    def test_compute_sma_returns_float(self) -> None:
+        df = pd.DataFrame({"Close": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]})
+        value = compute_sma(df, period=5)
         self.assertIsInstance(value, float)
 
 


### PR DESCRIPTION
## Summary
- ensure RSI and SMA helpers always return floats
- clarify docstrings for RSI and SMA
- test RSI and SMA return types

## Testing
- `python3 -m unittest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878522299e88323a2db7afbb6a0638d