### PR TITLE
Add Nitter fallback for tweet scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ export STOCK_SIGNAL_WEBHOOK="https://discord.com/api/webhooks/..."
 ### Offline social media cache
 
 Both scrapers automatically store results so they can be reused when the network
-is unavailable. Tweets are cached under `data/twitter_cache/<keyword>.txt` and
-Reddit posts under `data/reddit_cache/<keyword>.txt`. Each file contains one line
-per entry.
+is unavailable. The Twitter helper first tries `snscrape` and then a Nitter
+instance if scraping fails. Tweets are cached under
+`data/twitter_cache/<keyword>.txt` and Reddit posts under
+`data/reddit_cache/<keyword>.txt`. Each file contains one line per entry.

--- a/tests/test_scrape.py
+++ b/tests/test_scrape.py
@@ -29,7 +29,8 @@ class TestScrapeFallback(unittest.TestCase):
         cache_dir.mkdir(parents=True, exist_ok=True)
         (cache_dir / 'test.txt').write_text('cached tweet\n')
 
-        with patch('scrape.sntwitter.TwitterSearchScraper') as mock_scraper:
+        with patch('scrape.sntwitter.TwitterSearchScraper') as mock_scraper, \
+             patch('scrape.fetch_from_nitter', side_effect=Exception('fail')):
             mock_scraper.return_value.get_items.side_effect = Exception('fail')
             tweets = scrape.get_tweets(['test'], retries=1)
         self.assertEqual(tweets, ['cached tweet'])


### PR DESCRIPTION
## Summary
- add `fetch_from_nitter` helper to use a Nitter instance when snscrape fails
- update `get_tweets` to try Nitter before reading cached tweets
- patch scrape tests to mock out both snscrape and Nitter
- document the Nitter fallback in README

## Testing
- `python3 -m unittest -v`

------
https://chatgpt.com/codex/tasks/task_e_687866acc3b48323ba8f79764a88c47c