### PR TITLE
Add Playwright fallback for Twitter scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ export STOCK_SIGNAL_WEBHOOK="https://discord.com/api/webhooks/..."
 
 Both scrapers automatically store results so they can be reused when the network
 is unavailable. The Twitter helper first tries `snscrape` and then a Nitter
-instance if scraping fails. Tweets are cached under
+instance if scraping fails. If those methods fail and the optional
+`playwright` dependency is installed, a headless browser is launched to grab
+tweets directly from the live search page. Tweets are cached under
 `data/twitter_cache/<keyword>.txt` and Reddit posts under
 `data/reddit_cache/<keyword>.txt`. Each file contains one line per entry.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ technical-analysis
 discord-webhook
 apscheduler
 streamlit
+playwright

--- a/setup.sh
+++ b/setup.sh
@@ -13,3 +13,4 @@ fi
 
 python3.11 -m pip install --upgrade pip
 python3.11 -m pip install -r requirements.txt
+python3.11 -m playwright install

--- a/tests/test_scrape.py
+++ b/tests/test_scrape.py
@@ -37,6 +37,14 @@ class TestScrapeFallback(unittest.TestCase):
 
         shutil.rmtree('data')
 
+    def test_playwright_used_when_other_methods_fail(self):
+        with patch('scrape.sntwitter.TwitterSearchScraper') as mock_scraper, \
+             patch('scrape.fetch_from_nitter', return_value=[]), \
+             patch('scrape.fetch_with_playwright', return_value=['pwtweet']):
+            mock_scraper.return_value.get_items.side_effect = Exception('fail')
+            tweets = scrape.get_tweets(['test'], retries=1)
+        self.assertEqual(tweets, ['pwtweet'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- support Playwright-based scraping when snscrape and Nitter both fail
- document Playwright in the README
- install Playwright in setup script and add to requirements
- test Playwright fallback behaviour

## Testing
- `python3 -m unittest -v`

------
https://chatgpt.com/codex/tasks/task_e_6879071106008323a7202a6713058b30